### PR TITLE
Initialize Outlook add-in skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+build/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# Timing365
-add-in Outlook (bureau et web) pour le suivi d’activité individuelle
+# Timing365 Outlook Add-in
+
+This repository contains a React-based Office Add-in for Outlook. The project was
+bootstrapped from the official Office Add-in TaskPane React template. It uses
+React 17 and Fluent UI components.
+
+## Project Structure
+
+- `src/` – React source code
+- `public/` – Office manifest and static assets
+- `build/` – Webpack build output
+
+## Scripts
+
+- `npm run start` – Launch a development server at `https://localhost:3000`
+- `npm run build` – Build the production bundle into the `build/` folder
+
+The manifest at `public/manifest.xml` references `taskpane.html`, which is
+created by the Webpack build.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "timing365-addin",
+  "version": "0.1.0",
+  "description": "Outlook TaskPane add-in built with React and Fluent UI",
+  "scripts": {
+    "start": "webpack serve --mode development --open",
+    "build": "webpack --mode production"
+  },
+  "dependencies": {
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "@fluentui/react": "^8.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.0.0",
+    "ts-loader": "^9.0.0",
+    "webpack": "^5.0.0",
+    "webpack-cli": "^4.0.0",
+    "webpack-dev-server": "^4.0.0",
+    "html-webpack-plugin": "^5.3.1"
+  }
+}

--- a/public/manifest.xml
+++ b/public/manifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:type="MailApp">
+  <Id>9c8aad41-df24-4b86-9d50-000000000001</Id>
+  <Version>1.0.0.0</Version>
+  <ProviderName>Timing365</ProviderName>
+  <DefaultLocale>en-US</DefaultLocale>
+  <DisplayName DefaultValue="Timing365" />
+  <Description DefaultValue="Outlook add-in" />
+  <Hosts>
+    <Host Name="Mailbox" />
+  </Hosts>
+  <Requirements>
+    <Sets DefaultMinVersion="1.1">
+      <Set Name="Mailbox" />
+    </Sets>
+  </Requirements>
+  <DefaultSettings>
+    <SourceLocation DefaultValue="https://localhost:3000/taskpane.html" />
+  </DefaultSettings>
+  <Permissions>ReadWriteItem</Permissions>
+</OfficeApp>

--- a/public/taskpane.html
+++ b/public/taskpane.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Timing365 Add-in</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { PrimaryButton } from '@fluentui/react';
+
+export const App: React.FC = () => {
+  const onClick = () => {
+    console.log('Hello from Timing365 Add-in!');
+  };
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <h1>Timing365 Outlook Add-in</h1>
+      <PrimaryButton onClick={onClick}>Click me</PrimaryButton>
+    </div>
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { initializeIcons } from '@fluentui/react';
+import { App } from './App';
+
+initializeIcons();
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "esnext",
+    "jsx": "react",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "outDir": "./build",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src"]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,40 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = (env, argv) => {
+  const mode = argv.mode || 'production';
+  return {
+    mode,
+    entry: './src/index.tsx',
+    devtool: mode === 'development' ? 'inline-source-map' : false,
+    resolve: {
+      extensions: ['.ts', '.tsx', '.js']
+    },
+    output: {
+      filename: 'bundle.js',
+      path: path.resolve(__dirname, 'build'),
+      clean: true
+    },
+    module: {
+      rules: [
+        {
+          test: /\.tsx?$/,
+          use: 'ts-loader',
+          exclude: /node_modules/
+        }
+      ]
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(__dirname, 'public/taskpane.html'),
+        filename: 'taskpane.html'
+      })
+    ],
+    devServer: {
+      static: {
+        directory: path.join(__dirname, 'public')
+      },
+      port: 3000
+    }
+  };
+};


### PR DESCRIPTION
## Summary
- set up React 17 + Fluent UI project for an Outlook Task Pane
- add Office manifest and basic task pane html
- configure TypeScript and Webpack build

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_68822869743c832fb5a8ac44b45e82dd